### PR TITLE
Update JPro repo coordinates bintray -> jfrog.

### DIFF
--- a/pdfviewfx-demo/pom.xml
+++ b/pdfviewfx-demo/pom.xml
@@ -36,20 +36,15 @@
 
     <repositories>
         <repository>
-            <id>jcenter</id>
-            <url>https://jcenter.bintray.com/</url>
-        </repository>
-
-        <repository>
             <id>jpro - sandec repository</id>
-            <url>http://sandec.bintray.com/repo</url>
+            <url>https://sandec.jfrog.io/artifactory/repo</url>
         </repository>
     </repositories>
 
     <pluginRepositories>
         <pluginRepository>
             <id>jpro - sandec repository</id>
-            <url>http://sandec.bintray.com/repo</url>
+            <url>https://sandec.jfrog.io/artifactory/repo</url>
         </pluginRepository>
     </pluginRepositories>
 


### PR DESCRIPTION
Build currently fails since bintray shut down.
New coordinates taken from https://www.jpro.one/?page=docs/current/1.1/
Tested that build succeeds when using a clean maven cache.
GemsFX will need the same update.
Feel free to close this PR if it's more work than doing it yourself.