### PR TITLE
Update unitfx to 1.0.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
             <dependency>
                 <groupId>com.dlsc.unitfx</groupId>
                 <artifactId>unitfx</artifactId>
-                <version>1.0.9</version>
+                <version>1.0.10</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
I was hoping to find an upstream update to a transitive dependency on non-modular `javax.inject` to use `jakarta-inject.api`.

But we'll have to wait for the next release (2.1.4) to get this change:
https://github.com/unitsofmeasurement/indriya/commit/5c57d09bc154ef6f863635fd656d899f59330798