### PR TITLE
Fixes Issue #21

### DIFF
--- a/pdfviewfx/src/main/java/com/dlsc/pdfviewfx/skins/PDFViewSkin.java
+++ b/pdfviewfx/src/main/java/com/dlsc/pdfviewfx/skins/PDFViewSkin.java
@@ -987,6 +987,11 @@ public class PDFViewSkin extends SkinBase<PDFView> {
             this.page = page;
             this.scale = scale;
         }
+        
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+        	return super.cancel(false); // #21: Must not interrupt pdfbox otherwise the PDDocument will no longer be able to render pages
+        }
 
         @Override
         protected Image call() {


### PR DESCRIPTION
By not allowing Task.cancel to interrupt the thread we prevent unwanted closing of the RandomAccessReadBufferedFile within PDFBox.