### PR TITLE
25: Add workaround to demo for MacOS.

### DIFF
--- a/pdfviewfx-demo/src/main/java/com/dlsc/pdfviewfx/demo/PDFViewApp.java
+++ b/pdfviewfx-demo/src/main/java/com/dlsc/pdfviewfx/demo/PDFViewApp.java
@@ -6,6 +6,7 @@ import javafx.application.Application;
 import javafx.beans.binding.Bindings;
 import javafx.collections.ObservableList;
 
+import java.awt.GraphicsEnvironment;
 import java.awt.print.PrinterException;
 import java.awt.print.PrinterJob;
 
@@ -41,6 +42,7 @@ public class PDFViewApp extends Application {
 
     @Override
     public void start(Stage primaryStage) {
+        GraphicsEnvironment.getLocalGraphicsEnvironment();
         MenuItem loadItem = new MenuItem("Load PDF...");
         loadItem.setAccelerator(KeyCombination.valueOf("SHORTCUT+o"));
         loadItem.setOnAction(evt -> {


### PR DESCRIPTION
This will pre-initialize the `GraphicsEnvironment` in the JavaFX Application Thread thus avoiding the deadlock.