### PR TITLE
Better thread-handling and cleanup in PDFBoxDocument

### DIFF
--- a/pdfviewfx-demo/src/main/java/com/dlsc/pdfviewfx/demo/PDFViewApp.java
+++ b/pdfviewfx-demo/src/main/java/com/dlsc/pdfviewfx/demo/PDFViewApp.java
@@ -6,11 +6,9 @@ import javafx.application.Application;
 import javafx.beans.binding.Bindings;
 import javafx.collections.ObservableList;
 
-import java.awt.GraphicsEnvironment;
 import java.awt.print.PrinterException;
 import java.awt.print.PrinterJob;
 
-import javafx.geometry.Insets;
 import javafx.scene.Scene;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuBar;
@@ -18,12 +16,10 @@ import javafx.scene.control.MenuItem;
 import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.layout.Priority;
-import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.stage.FileChooser;
 import javafx.stage.FileChooser.ExtensionFilter;
 import javafx.stage.Stage;
-import org.scenicview.ScenicView;
 
 import javax.swing.SwingUtilities;
 import java.io.File;

--- a/pdfviewfx/src/main/java/com/dlsc/pdfviewfx/PDFBoxDocument.java
+++ b/pdfviewfx/src/main/java/com/dlsc/pdfviewfx/PDFBoxDocument.java
@@ -57,7 +57,6 @@ public class PDFBoxDocument implements SearchableDocument {
     }
 
     private void initCaches() {
-        long start = System.currentTimeMillis();
         numberOfPages = document.getNumberOfPages();
         landscapeCache = new BitSet(numberOfPages);
         for (int i = 0; i < numberOfPages; i++) {
@@ -66,9 +65,6 @@ public class PDFBoxDocument implements SearchableDocument {
             boolean landscape = cropBox.getHeight() < cropBox.getWidth();            
             landscapeCache.set(i, landscape);
         }
-        long end = System.currentTimeMillis();
-        System.out.println("Filling caches took " + (end-start) + " ms.");
-        
     }
 
     private PDDocument createDocument() {

--- a/pdfviewfx/src/main/java/com/dlsc/pdfviewfx/PDFBoxDocument.java
+++ b/pdfviewfx/src/main/java/com/dlsc/pdfviewfx/PDFBoxDocument.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Writer;
 import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.List;
 
 /**
@@ -36,11 +37,14 @@ public class PDFBoxDocument implements SearchableDocument {
 
     private byte[] contentBytes;
     private File contentFile;
+    private int numberOfPages;
+    private BitSet landscapeCache;
 
     public PDFBoxDocument(InputStream pdfInputStream) {
         try {
             contentBytes = pdfInputStream.readAllBytes();
             document = createDocument();
+            initCaches();
         } catch (IOException e) {
             throw new DocumentProcessingException(e);
         }
@@ -49,6 +53,22 @@ public class PDFBoxDocument implements SearchableDocument {
     public PDFBoxDocument(File file) {
         contentFile = file;
         document = createDocument();
+        initCaches();
+    }
+
+    private void initCaches() {
+        long start = System.currentTimeMillis();
+        numberOfPages = document.getNumberOfPages();
+        landscapeCache = new BitSet(numberOfPages);
+        for (int i = 0; i < numberOfPages; i++) {
+            PDPage page = document.getPage(i);
+            PDRectangle cropBox = page.getCropBox();
+            boolean landscape = cropBox.getHeight() < cropBox.getWidth();            
+            landscapeCache.set(i, landscape);
+        }
+        long end = System.currentTimeMillis();
+        System.out.println("Filling caches took " + (end-start) + " ms.");
+        
     }
 
     private PDDocument createDocument() {
@@ -60,15 +80,13 @@ public class PDFBoxDocument implements SearchableDocument {
     }
 
     @Override
-    public synchronized int getNumberOfPages() {
-        return document.getNumberOfPages();
+    public int getNumberOfPages() {
+        return numberOfPages;
     }
 
     @Override
-    public synchronized boolean isLandscape(int pageNumber) {
-        PDPage page = document.getPage(pageNumber);
-        PDRectangle cropBox = page.getCropBox();
-        return cropBox.getHeight() < cropBox.getWidth();
+    public boolean isLandscape(int pageNumber) {
+        return landscapeCache.get(pageNumber);
     }
 
     @Override
@@ -77,7 +95,7 @@ public class PDFBoxDocument implements SearchableDocument {
     }
 
     @Override
-    public synchronized BufferedImage renderPage(int pageNumber, float scale) {
+    public BufferedImage renderPage(int pageNumber, float scale) {
         PDFRenderer renderer = new PDFRenderer(document);
         BufferedImage bufferedImage;
 
@@ -134,8 +152,8 @@ public class PDFBoxDocument implements SearchableDocument {
             }
         };
 
-        try {
-            stripper.writeText(createDocument(), writer);
+        try (PDDocument doc = createDocument()) {
+            stripper.writeText(doc, writer);
         } catch (IOException e) {
             throw new DocumentProcessingException(e);
         }
@@ -144,7 +162,7 @@ public class PDFBoxDocument implements SearchableDocument {
     }
 
     @Override
-    public synchronized void close() {
+    public void close() {
         try {
             document.close();
         } catch (IOException e) {

--- a/pdfviewfx/src/main/java/com/dlsc/pdfviewfx/PDFView.java
+++ b/pdfviewfx/src/main/java/com/dlsc/pdfviewfx/PDFView.java
@@ -10,11 +10,9 @@ import javafx.scene.control.Control;
 import javafx.scene.control.Skin;
 import javafx.scene.paint.Color;
 
-import java.awt.GraphicsEnvironment;
 import java.awt.image.BufferedImage;
 import java.awt.print.Pageable;
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Objects;
@@ -32,9 +30,6 @@ public class PDFView extends Control {
      */
     public PDFView() {
         super();
-
-        // to avoid threading deadlock, see issue #25 and pull request #26
-        GraphicsEnvironment.getLocalGraphicsEnvironment();
 
         getStyleClass().add("pdf-view");
         setFocusTraversable(false);

--- a/pdfviewfx/src/main/java/com/dlsc/pdfviewfx/skins/PDFViewSkin.java
+++ b/pdfviewfx/src/main/java/com/dlsc/pdfviewfx/skins/PDFViewSkin.java
@@ -995,6 +995,11 @@ public class PDFViewSkin extends SkinBase<PDFView> {
             this.page = page;
             this.scale = scale;
         }
+        
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            return super.cancel(false); // #21: Must not interrupt pdfbox otherwise the PDDocument will no longer be able to render pages
+        }        
 
         @Override
         protected Image call() {


### PR DESCRIPTION
This PR improved PDFBoxDocument by removing the need for synchronized methods:
* `getNumberOfPages` and `isLandscape` delivered pre-computed information
* `renderPage` will be the only method that accesses the PDDocument. It is always called from the service, thus no multi-threading problems
* `close` will only be called once, so `synchronized` was never really needed here.

It also fixed the (minor) resource leak in `com.dlsc.pdfviewfx.PDFBoxDocument.getSearchResults(String)` by closing the PDDocument created for searching.

It does **not** fix the (minor) resource leak in `com.dlsc.pdfviewfx.PDFBoxDocument.getPageable()`, this should / will be handled as Issue #30.

It also removes the need to work around the initialisation problems found in Issue #25. Since there are no synchronized methods anymore, the Mac JDK will no longer hang. Thus the PR also removes the workaround.

It also includes some minor cleanup (unneeded imports removed)