### PR TITLE
35: Add text selection.

### DIFF
--- a/pdfviewfx-demo/src/main/java/com/dlsc/pdfviewfx/demo/PDFViewApp.java
+++ b/pdfviewfx-demo/src/main/java/com/dlsc/pdfviewfx/demo/PDFViewApp.java
@@ -63,7 +63,7 @@ public class PDFViewApp extends Application {
         }
 
         MenuItem closeItem = new MenuItem("Close PDF");
-        closeItem.setAccelerator(KeyCombination.valueOf("SHORTCUT+c"));
+        closeItem.setAccelerator(KeyCombination.valueOf("SHORTCUT+w"));
         closeItem.setOnAction(evt -> pdfView.unload());
         closeItem.disableProperty().bind(Bindings.isNull(pdfView.documentProperty()));
 

--- a/pdfviewfx/src/main/java/com/dlsc/pdfviewfx/Selection.java
+++ b/pdfviewfx/src/main/java/com/dlsc/pdfviewfx/Selection.java
@@ -1,0 +1,59 @@
+package com.dlsc.pdfviewfx;
+
+import java.util.List;
+
+import javafx.geometry.Rectangle2D;
+
+/** Selection represents a textual selection within the PDF file. */
+public class Selection {
+    private int pageNumber;
+    private final List<Rectangle2D> marker;
+    private final String selectedText;
+
+    public enum Mode {
+        CHARACTER, WORD, LINE;
+
+        public static Mode forClickCount(int clickCount) {
+            return switch (clickCount) {
+                case 1 -> CHARACTER;
+                case 2 -> WORD;
+                case 3 -> LINE;
+                default -> CHARACTER;
+            };
+        }
+    }
+    /**
+     * Constructs a new selection.
+     *
+     * @param pageNumber  The number of the page the selection lives in
+     * @param marker The list of rectangles to be highlighted (in PDF coordinates)
+     */
+    public Selection(int pageNumber, List<Rectangle2D> marker, String selectedText) {
+        this.pageNumber = pageNumber;
+        this.marker = marker;
+        this.selectedText = selectedText;
+    }
+
+    public List<Rectangle2D> getMarker() {
+        return marker;
+    }
+
+    public List<Rectangle2D> getScaledMarker(double scale) {
+        return marker.stream()
+            .map(m -> new Rectangle2D(m.getMinX() * scale, m.getMinY() * scale, m.getWidth() * scale, m.getHeight() * scale))
+            .toList();
+    }
+
+    public int getPageNumber() {
+        return pageNumber;
+    }
+
+    public String getSelectedText() {
+        return selectedText;
+    }
+
+    @Override
+    public String toString() {
+        return "[selection page: " + pageNumber + ", rects: " + marker.size() + "]";
+    }
+}

--- a/pdfviewfx/src/main/java/com/dlsc/pdfviewfx/TextPositionExtractor.java
+++ b/pdfviewfx/src/main/java/com/dlsc/pdfviewfx/TextPositionExtractor.java
@@ -1,0 +1,48 @@
+package com.dlsc.pdfviewfx;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.apache.pdfbox.text.TextPosition;
+
+import javafx.geometry.Point2D;
+import javafx.geometry.Rectangle2D;
+
+public class TextPositionExtractor  extends PDFTextStripper {
+
+    private int pageNumber = -1;
+    private List<TextPosition> textPositions = new ArrayList<>(2048);
+    
+    public TextPositionExtractor(int pageNumber) {
+        setStartPage(pageNumber+1);
+        setEndPage(pageNumber+1);
+        this.pageNumber = pageNumber;
+    }
+
+    @Override
+    protected void writeString(String text, List<TextPosition> positions) {
+        for (TextPosition textPosition : positions) {
+            textPositions.add(textPosition);
+//            System.out.println(
+//                    "page: " + pageNumber + ": " + textPosition + 
+//                    " from " + textPosition.getXDirAdj() + " / " + textPosition.getYDirAdj() + 
+//                    ", width: " + textPosition.getWidth() + ", height: " + textPosition.getHeight());
+        }
+    }
+    
+    public int getPageNumber() {
+        return pageNumber;
+    }
+    
+    public List<Rectangle2D> getSelectionRectangles(Point2D start, Point2D end) {
+        List<Rectangle2D> selectionRectangles = new ArrayList<>();
+        Rectangle2D cropBox = new Rectangle2D(start.getX(), start.getY(), end.getX() - start.getX(), end.getY() - start.getY());
+        for (TextPosition candidate : textPositions) {
+            if (cropBox.contains(candidate.getXDirAdj(), candidate.getYDirAdj())) {
+                selectionRectangles.add(new Rectangle2D(candidate.getXDirAdj(), candidate.getYDirAdj() - candidate.getHeight(), candidate.getWidth(), candidate.getHeight()));
+            }
+        }
+        return selectionRectangles;
+    }
+}

--- a/pdfviewfx/src/main/java/com/dlsc/pdfviewfx/impl/SelectionExtractor.java
+++ b/pdfviewfx/src/main/java/com/dlsc/pdfviewfx/impl/SelectionExtractor.java
@@ -1,0 +1,93 @@
+package com.dlsc.pdfviewfx.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.dlsc.pdfviewfx.Selection;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.apache.pdfbox.text.TextPosition;
+
+import javafx.geometry.Point2D;
+import javafx.geometry.Rectangle2D;
+
+/**
+ * SelectionExtractor allows to get selections for a given page of the pdf file.
+ */
+public class SelectionExtractor extends PDFTextStripper {
+
+    private final int pageNumber;
+    private final List<TextLine> lines = new ArrayList<>(64);
+    private TextLine currentLine;
+
+    public SelectionExtractor(int pageNumber) {
+        setStartPage(pageNumber + 1);
+        setEndPage(pageNumber + 1);
+        setSortByPosition(true);
+        this.pageNumber = pageNumber;
+    }
+
+    @Override
+    protected void writeString(String text, List<TextPosition> positions) {
+        for (TextPosition textPosition : positions) {
+            if (currentLine == null) {
+                currentLine = new TextLine(textPosition);
+                lines.add(currentLine);
+            } else {
+                TextLine oldLine = currentLine;
+                currentLine = currentLine.add(textPosition);
+                if (currentLine != oldLine) {
+                    lines.add(currentLine);
+                }
+            }
+        }
+    }
+
+    public int getPageNumber() {
+        return pageNumber;
+    }
+
+    public Selection getSelection(int pageNumber, Point2D start, Point2D end, Selection.Mode mode) {
+        if (start.getY() > end.getY()) {
+            Point2D tmp = end;
+            end = start;
+            start = tmp;
+        }
+        List<Rectangle2D> selectionRectangles = new ArrayList<>();
+        TextLine startLine = getFirstLineAt(start.getY());
+        TextLine endLine = getLastLineAt(end.getY());
+        StringBuilder selectionText = new StringBuilder();
+        if (startLine != null && endLine != null) {
+            if (startLine == endLine) {
+                startLine.collectSelection(start.getX(), end.getX(), mode, selectionRectangles, selectionText);
+            } else {
+                startLine.collectSelection(start.getX(), Double.MAX_VALUE, mode, selectionRectangles, selectionText);
+                int startIdx = lines.indexOf(startLine) + 1;
+                int endIdx = lines.indexOf(endLine);
+                for (int idx = startIdx; idx < endIdx; idx++) {
+                    selectionText.append("\n");
+                    TextLine line = lines.get(idx);
+                    line.collectSelection(Double.MIN_VALUE, Double.MAX_VALUE, mode, selectionRectangles, selectionText);
+                }
+                selectionText.append("\n");
+                endLine.collectSelection(Double.MIN_VALUE, end.getX(), mode, selectionRectangles, selectionText);
+            }
+        }
+
+        return selectionText.isEmpty() ? null : new Selection(pageNumber, selectionRectangles, selectionText.toString());
+    }
+
+    private TextLine getFirstLineAt(double y) {
+        return lines.stream()
+                .filter(line -> line.getBottom() >= y)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private TextLine getLastLineAt(double y) {
+        return lines.reversed().stream()
+                .filter(line -> line.getTop() <= y)
+                .findFirst()
+                .orElse(null);
+    }
+
+}

--- a/pdfviewfx/src/main/java/com/dlsc/pdfviewfx/impl/TextLine.java
+++ b/pdfviewfx/src/main/java/com/dlsc/pdfviewfx/impl/TextLine.java
@@ -1,0 +1,147 @@
+package com.dlsc.pdfviewfx.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.dlsc.pdfviewfx.Selection;
+import org.apache.pdfbox.pdmodel.font.PDFont;
+import org.apache.pdfbox.pdmodel.font.PDFontDescriptor;
+import org.apache.pdfbox.text.TextPosition;
+
+import javafx.geometry.Rectangle2D;
+
+/** TextLine represents one line of text in a pdf file. */
+class TextLine {
+    private List<TextPosition> textPositions = new ArrayList<TextPosition>(64);
+    private double top = Double.MAX_VALUE;
+    private double bottom = 0;
+
+    TextLine(TextPosition textPosition) {
+        addPosition(textPosition);
+    }
+
+    /** Add textPosition or create new line.
+     * @param textPosition The text position to add to this line
+     * @return this line, if the given text position fit into this line or a new TextLine object
+     */
+    TextLine add(TextPosition textPosition) {
+        TextLine result = this;
+        if (isOnThisLine(textPosition)) {
+            addPosition(textPosition);
+        } else {
+            result = new TextLine(textPosition);
+        }
+        return result;
+    }
+    
+    boolean containsHeight(double y) {
+        return top <= y && y <= bottom;
+    }
+
+    double getBottom() {
+        return bottom;
+    }
+
+    double getTop() {
+        return top;
+    }
+
+    void collectSelection(double startx, double endx, Selection.Mode mode, List<Rectangle2D> selectionRectangles, StringBuilder selectionText) {
+        if (startx > endx) {
+            double tmp = endx;
+            endx = startx;
+            startx = tmp;
+        }
+        int startIndex = getStartIndex(startx, mode);
+        int endIndex = getEndIndex(endx, mode);
+        if (startIndex != -1 && endIndex != -1) {
+            for (int idx = startIndex; idx <= endIndex; idx++) {
+                selectionText.append(textPositions.get(idx).getUnicode());
+            }
+            TextPosition start = textPositions.get(startIndex);
+            TextPosition end = textPositions.get(endIndex);
+            selectionRectangles.add(new Rectangle2D(start.getX(), top, end.getEndX() - start.getX(), bottom - top));
+        }
+    }
+
+    private int getStartIndex(double startx, Selection.Mode mode) {
+        int startIndex = -1;
+        boolean lastWasBlank = true;
+        int lastWordStartIdx = -1;
+
+        int idx = 0;
+        while (idx < textPositions.size() && startIndex == -1) {
+            TextPosition textPosition = textPositions.get(idx);
+            double middle = textPosition.getX() + textPosition.getWidth() / 2;
+            if (startx <= middle) {
+                startIndex = idx;
+            }
+
+            if (lastWasBlank) {
+                lastWordStartIdx = idx;
+            }
+            lastWasBlank = textPosition.getUnicode().isBlank();
+
+            idx++;
+        }
+
+        return switch (mode) {
+            case CHARACTER -> startIndex;
+            case WORD -> lastWordStartIdx;
+            case LINE -> 0;
+        };
+    }
+
+    private int getEndIndex(double endx, Selection.Mode mode) {
+        int endIndex = -1;
+        boolean lastWasBlank = true;
+        int lastWordEndIdx = -1;
+
+        int idx = textPositions.size() - 1;
+        while (idx >= 0 && endIndex == -1) {
+            TextPosition textPosition = textPositions.get(idx);
+            double middle = textPosition.getX() + textPosition.getWidth() / 2;
+            if (middle <= endx) {
+                endIndex = idx;
+            }
+
+            if (lastWasBlank) {
+                lastWordEndIdx = idx;
+            }
+            lastWasBlank = textPosition.getUnicode().isBlank();
+
+            idx--;
+        }
+
+        return switch (mode) {
+            case CHARACTER -> endIndex;
+            case WORD -> lastWordEndIdx;
+            case LINE -> textPositions.size() - 1;
+        };
+    }
+
+    private void addPosition(TextPosition textPosition) {
+        PDFont font = textPosition.getFont();
+        float fontSize = textPosition.getFontSizeInPt();
+        PDFontDescriptor fontDescriptor = font.getFontDescriptor();
+        float descenderHeight = Math.abs((fontDescriptor.getDescent() / 1000.0f) * fontSize);
+        float ascenderHeight = Math.abs((fontDescriptor.getAscent() / 1000.0f) * fontSize);
+
+        top = Math.min(top, textPosition.getYDirAdj() - ascenderHeight + descenderHeight);
+        bottom = Math.max(bottom, textPosition.getYDirAdj() + descenderHeight);
+        textPositions.add(textPosition);
+    }
+    
+    private boolean isOnThisLine(TextPosition textPosition) {
+        TextPosition lastTextPosition = textPositions.getLast();
+        float tolerance = lastTextPosition.getHeight() / 2; 
+        return Math.abs(lastTextPosition.getYDirAdj() - textPosition.getYDirAdj()) < tolerance;  
+    }
+
+    @Override
+    public String toString() {
+        return "TextLine [top: " + top + ", bottom: " + bottom + ", text: " +
+            textPositions.stream().map(TextPosition::getUnicode).collect(Collectors.joining());
+    }
+}

--- a/pdfviewfx/src/main/java/com/dlsc/pdfviewfx/skins/PDFViewSkin.java
+++ b/pdfviewfx/src/main/java/com/dlsc/pdfviewfx/skins/PDFViewSkin.java
@@ -4,6 +4,8 @@ import com.dlsc.pdfviewfx.PDFView;
 import com.dlsc.pdfviewfx.PDFView.Document;
 import com.dlsc.pdfviewfx.PDFView.SearchResult;
 import com.dlsc.pdfviewfx.PDFView.SearchableDocument;
+import com.dlsc.pdfviewfx.Selection;
+
 import javafx.animation.FadeTransition;
 import javafx.animation.ParallelTransition;
 import javafx.animation.ScaleTransition;
@@ -20,8 +22,11 @@ import javafx.concurrent.Task;
 import javafx.embed.swing.SwingFXUtils;
 import javafx.geometry.Bounds;
 import javafx.geometry.Orientation;
+import javafx.geometry.Point2D;
+import javafx.geometry.Point3D;
 import javafx.geometry.Pos;
 import javafx.geometry.Rectangle2D;
+import javafx.scene.Cursor;
 import javafx.scene.Group;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
@@ -31,9 +36,7 @@ import javafx.scene.control.*;
 import javafx.scene.control.skin.VirtualFlow;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import javafx.scene.input.KeyCode;
-import javafx.scene.input.KeyEvent;
-import javafx.scene.input.ScrollEvent;
+import javafx.scene.input.*;
 import javafx.scene.layout.*;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Rectangle;
@@ -67,6 +70,8 @@ public class PDFViewSkin extends SkinBase<PDFView> {
     private final ListView<PageSearchResult> searchResultListView = new ListView<>();
 
     private final Map<Integer, Image> imageCache = new HashMap<>();
+    
+    private SelectionService selectionService = new SelectionService();
 
     public PDFViewSkin(PDFView view) {
         super(view);
@@ -281,6 +286,56 @@ public class PDFViewSkin extends SkinBase<PDFView> {
             return document.getSearchResults(searchText);
         }
     }
+    
+    class SelectionService extends Service<Selection> {
+        private Point2D start, end;
+        private Selection.Mode mode;
+        
+        public void setStart(Point2D start) {
+            this.start = start;
+            this.end = null;
+        }
+        
+        public void setEnd(Point2D end) {
+            this.end = end;
+        }
+
+        public void setMode(Selection.Mode mode) {
+            this.mode = mode;
+        }
+
+        @Override
+        protected Task<Selection> createTask() {
+            return new SelectionTask(getSkinnable().getDocument(), getSkinnable().getPage(), start, end, mode);
+        }
+    }
+    
+    static class SelectionTask extends Task<Selection> {
+
+        private final Document document;
+        private final int pageNumber;
+        private final Point2D start, end;
+        private final Selection.Mode mode;
+
+
+        public SelectionTask(Document document, int pageNumber, Point2D start, Point2D end, Selection.Mode mode) {
+            this.document = document;
+            this.pageNumber = pageNumber;
+            this.start = start;
+            this.end = end;
+            this.mode = mode;
+        }
+
+        @Override
+        protected Selection call() throws Exception {
+            if (document instanceof PDFView.SelectableDocument selectableDocument && start != null && end != null) {
+                return selectableDocument.getSelection(pageNumber, start, end, mode);
+            } else {
+                return new Selection(-1,  List.of(), "");
+            }
+        }
+    }
+    
 
     private final DoubleProperty requestedVValue = new SimpleDoubleProperty(-1);
 
@@ -583,6 +638,7 @@ public class PDFViewSkin extends SkinBase<PDFView> {
 
             pdfView.selectedSearchResultProperty().addListener(it -> bounceSearchResult());
             pdfView.getSearchResults().addListener((Observable it) -> mainAreaRenderService.restart());
+            pdfView.selectionProperty().addListener((Observable it) -> mainAreaRenderService.restartLater());
 
             mainAreaRenderService.setOnSucceeded(evt -> {
                 double vValue = requestedVValue.get();
@@ -649,6 +705,21 @@ public class PDFViewSkin extends SkinBase<PDFView> {
                         }
                     };
 
+            selectionService.setOnCancelled(evt -> {
+                if (selectionService.getValue() != null) { // use intermediate values for smooth selection
+                    getSkinnable().setSelection(selectionService.getValue());
+                }
+            });
+            selectionService.setOnSucceeded(evt -> {
+                getSkinnable().setSelection(selectionService.getValue());
+            });
+            selectionService.setOnFailed(evt -> {
+                if (selectionService.getException() instanceof Exception e) {
+                    e.printStackTrace();
+                }
+            });
+
+                    
             wrapper = new StackPane() {
                 @Override
                 protected void layoutChildren() {
@@ -666,9 +737,9 @@ public class PDFViewSkin extends SkinBase<PDFView> {
                             bouncer.setWidth(marker.getWidth() * scale);
                             bouncer.setHeight(marker.getHeight() * scale);
                         }
+                        Platform.runLater(() -> ensureVisible(bouncer));
                     }
 
-                    Platform.runLater(() -> ensureVisible(bouncer));
                 }
 
                 private void ensureVisible(Node node) {
@@ -711,6 +782,34 @@ public class PDFViewSkin extends SkinBase<PDFView> {
 
             group = new Group(wrapper);
             pane.getChildren().addAll(group);
+            
+            group.addEventHandler(MouseEvent.MOUSE_PRESSED, evt -> {
+                if (evt.getButton() == MouseButton.PRIMARY) {
+                    group.setCursor(Cursor.TEXT);
+                    selectionService.setStart(getMouseEventPoint(evt));
+                    selectionService.setEnd(getMouseEventPoint(evt));
+                    selectionService.setMode(Selection.Mode.forClickCount(evt.getClickCount()));
+                    selectionService.restart();
+                    evt.consume();
+                }
+            });
+            
+            group.addEventHandler(MouseEvent.MOUSE_RELEASED, evt -> {
+                if (evt.getButton() == MouseButton.PRIMARY) {
+                    group.setCursor(Cursor.DEFAULT);
+                    selectionService.setEnd(getMouseEventPoint(evt));
+                    selectionService.restart();
+                    evt.consume();
+                }
+            });
+            
+            group.addEventHandler(MouseEvent.MOUSE_DRAGGED, evt -> {
+                if (evt.getButton() == MouseButton.PRIMARY) {
+                    selectionService.setEnd(getMouseEventPoint(evt));
+                    selectionService.restart();
+                    evt.consume();
+                }
+            });
 
             /*
              * THIS HAS TO BE AN INVALIDATION LISTENER AND NOT A CHANGE LISTENER, OTHERWISE
@@ -804,6 +903,17 @@ public class PDFViewSkin extends SkinBase<PDFView> {
             updateScrollbarPolicies();
 
             layoutImage();
+        }
+        
+        private Point2D getMouseEventPoint(MouseEvent evt) {
+            double ImageToWrapperRatio = imageView.getImage().getWidth() / wrapper.getWidth();
+            Point3D point = evt.getPickResult().getIntersectedPoint();
+            
+            Point2D pointInImageCoordinates = new Point2D(
+                point.getX() * ImageToWrapperRatio / mainAreaRenderService.getScale(), 
+                point.getY() * ImageToWrapperRatio / mainAreaRenderService.getScale()
+            );
+            return pointInImageCoordinates;
         }
 
         private ParallelTransition parallel;
@@ -932,6 +1042,7 @@ public class PDFViewSkin extends SkinBase<PDFView> {
     private class RenderService extends Service<Image> {
 
         private final boolean thumbnailRenderer;
+        private volatile boolean restartLater;
 
         public RenderService(boolean thumbnailRenderer) {
             this.thumbnailRenderer = thumbnailRenderer;
@@ -971,6 +1082,22 @@ public class PDFViewSkin extends SkinBase<PDFView> {
         @Override
         protected Task<Image> createTask() {
             return new RenderTask(thumbnailRenderer, getPage(), getScale());
+        }
+        
+        public void restartLater() {
+            if (isRunning()) {
+                restartLater = true;
+            } else {
+                restart();
+            }
+        }
+        
+        @Override
+        protected void succeeded() {
+            if (restartLater) {
+                restartLater = false;
+                restart();
+            }
         }
     }
 
@@ -1012,6 +1139,7 @@ public class PDFViewSkin extends SkinBase<PDFView> {
             // only highlight search results in the main view (for performance reasons)
             if (!thumbnail) {
                 highlightSearchResults(pageNumber, scale, bufferedImage);
+                highlightSelection(pageNumber, scale, bufferedImage);
             }
 
             return SwingFXUtils.toFXImage(bufferedImage, null);
@@ -1039,6 +1167,26 @@ public class PDFViewSkin extends SkinBase<PDFView> {
                             (int) highlightMarker.getWidth(),
                             (int) highlightMarker.getHeight());
                 });
+            }
+        }
+        
+        private void highlightSelection(int pageNumber, float scale, BufferedImage bufferedImage) {
+            Selection selection = getSkinnable().getSelection();
+            if (selection != null && selection.getPageNumber() == pageNumber) {
+                Graphics2D graphics = (Graphics2D) bufferedImage.getGraphics();
+                graphics.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, .5f));
+
+                Color selectionColor = getSkinnable().getSelectionColor();
+
+                graphics.setStroke(new BasicStroke(8));
+                graphics.setColor(new java.awt.Color((int) (255 * selectionColor.getRed()), (int) (255 * selectionColor.getGreen()), (int) (255 * selectionColor.getBlue())));
+                selection.getScaledMarker(scale).forEach(highlightMarker -> {
+                    graphics.fillRect(
+                            (int) highlightMarker.getMinX(),
+                            (int) highlightMarker.getMinY(),
+                            (int) highlightMarker.getWidth(),
+                            (int) highlightMarker.getHeight());
+                });                
             }
         }
     }


### PR DESCRIPTION
This PR adds text selection (and copying text to clipboard) to PDFViewFX.

Of note:
* I have changed the "Close PDF" Accelerator in the demo app to Shortcut+W so that Shortcut+C can be used for clipboard copy.
* double clicking will enter "word by word" selection mode
* triple clicking will enter "line by line" selection mode
* RenderService has been expanded by a restartLater method that will reduce the number of service restarts. This has improved the smoothness of selections.